### PR TITLE
Remove legacy smallfiles flag for MongoDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,4 @@ services:
       - ./.data/db:/data/db
     ports:
       - 27017:27017
-    command: mongod --smallfiles --logpath=/dev/null # --quiet
+    command: mongod --logpath=/dev/null # --quiet


### PR DESCRIPTION
`--smallfiles` was removed in version 4.2: https://docs.mongodb.com/manual/release-notes/4.2/#mmapv1-specific-configuration-options. Since the `latest` tag is specified, the database now fails to startup. 

```
Starting mongodb ... done
Starting go-clean-architecture ... done
Attaching to mongodb, go-clean-architecture
mongodb    | Error parsing command line: unrecognised option '--smallfiles'
mongodb    | try 'mongod --help' for more information
```